### PR TITLE
necessary JSON header for parity

### DIFF
--- a/lib/ethereumex/http_client.ex
+++ b/lib/ethereumex/http_client.ex
@@ -16,7 +16,7 @@ defmodule Ethereumex.HttpClient do
 
   @spec post_request(binary()) :: {:ok | :error, any()}
   defp post_request(payload) do
-    response = rpc_url() |> HTTPoison.post(payload)
+    response = rpc_url() |> HTTPoison.post(payload, [{"Content-Type", "application/json"}])
 
     case response do
       {:ok, %HTTPoison.Response{body: body, status_code: code}} ->


### PR DESCRIPTION
You can test it your self by calling any JSON RPC method to any parity client.