### PR TITLE
Don't crash if response body doesn't contain valid JSON.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.3.1
+* Handle failed HTTP requests more gracefully
 # 0.3.0
 * Breaking: Use `:url` config variable instead of `:host`, `:port` and `:scheme`
 # 0.2.0

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Ethereumex.Mixfile do
 
   def project do
     [app: :ethereumex,
-     version: "0.3.0",
+     version: "0.3.1",
      elixir: "~> 1.6",
      description: "Elixir JSON-RPC client for the Ethereum blockchain",
      package: [


### PR DESCRIPTION
Uses `Poison.decode` instead of its throwing variant `Poison.decode!` and uses the `with` macro for graceful error handling.

Fixes #18 