### PR TITLE
Increase timeout on the GenServer sync calls for macro functions

### DIFF
--- a/lib/ethereumex/client/macro.ex
+++ b/lib/ethereumex/client/macro.ex
@@ -442,7 +442,7 @@ defmodule Ethereumex.Client.Macro do
       end
 
       defp server_request(params) do
-        GenServer.call(__MODULE__, {:request, params})
+        GenServer.call(__MODULE__, {:request, params}, 60_000)
       end
 
       def start_link do


### PR DESCRIPTION
I was able to configure the HTTPoison `http_options` via the app config variables but no matter what I increased the `timeout` values to, the `GenServer.call` function kept timing out. [I learned that there is a default timeout of `5000` added to all `GenServer.call` calls](https://hexdocs.pm/elixir/GenServer.html#call/3).

Wanted to open this PR up for discussion, should this value be hard coded at some high value? Should we make it configurable? This value should always be higher than the http `timeout` that we set, otherwise, it'll crash before the http call times out.

Let me know what your thoughts are and thanks for creating / maintaining this package!