### PR TITLE
feat: allow configuring GenServer timeout for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ config :ethereumex,
   url: "http://localhost:8545"
 ```
 
+You can also configure the `GenServer` request timeout for requests sent to the Ethereum JSON-RPC
+(you can also overwrite this configuration in `opts` used when calling the client):
+
+```elixir
+config :ethereumex,
+  request_timeout: 10_000 # default is 5000 ms
+```
+
 ## Usage
 
 ### Available methods:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,5 @@
 use Mix.Config
 
+config :ethereumex, request_timeout: 5000
+
 import_config "#{Mix.env()}.exs"

--- a/lib/ethereumex/client/macro.ex
+++ b/lib/ethereumex/client/macro.ex
@@ -445,7 +445,8 @@ defmodule Ethereumex.Client.Macro do
       end
 
       defp server_request(params, opts \\ []) do
-        GenServer.call(__MODULE__, {:request, params, opts})
+        timeout = Keyword.get(opts, :request_timeout, Ethereumex.Config.request_timeout())
+        GenServer.call(__MODULE__, {:request, params, opts}, timeout)
       end
 
       def start_link do

--- a/lib/ethereumex/config.ex
+++ b/lib/ethereumex/config.ex
@@ -20,4 +20,9 @@ defmodule Ethereumex.Config do
   def http_options do
     Application.get_env(:ethereumex, :http_options, [])
   end
+
+  @spec request_timeout() :: integer()
+  def request_timeout do
+    Application.get_env(:ethereumex, :request_timeout, 5000)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,11 @@ defmodule Ethereumex.Mixfile do
   end
 
   def application do
-    [extra_applications: [:logger], mod: {Ethereumex, []}]
+    [
+      env: [request_timeout: 5000],
+      extra_applications: [:logger],
+      mod: {Ethereumex, []}
+    ]
   end
 
   defp deps do


### PR DESCRIPTION
the change is motivated by getting GenServer's timeouts when calling a slow geth instance. Now one can either configure the timeout on a `config.exs` level or pass the `:request_timeout` keyword argument to the request functions.