### PR TITLE
Add WebSocket Support

### DIFF
--- a/lib/ethereumex.ex
+++ b/lib/ethereumex.ex
@@ -19,6 +19,8 @@ defmodule Ethereumex do
     path = Enum.join([System.user_home!(), Ethereumex.Config.ipc_path()])
 
     [
+      worker(Ethereumex.WebSocketServer, [Ethereumex.Config.web3_url()]),
+      worker(Ethereumex.WebSocketClient, []),
       worker(Ethereumex.IpcServer, [%{path: path}]),
       worker(Ethereumex.IpcClient, [])
     ]

--- a/lib/ethereumex/client/base_client.ex
+++ b/lib/ethereumex/client/base_client.ex
@@ -448,7 +448,7 @@ defmodule Ethereumex.Client.BaseClient do
       def single_request(payload, opts \\ []) do
         payload
         |> encode_payload
-        |> post_request(opts)
+        |> post_request(opts, payload["id"])
       end
 
       @spec encode_payload(map()) :: binary()
@@ -467,11 +467,11 @@ defmodule Ethereumex.Client.BaseClient do
         end)
       end
 
-      defp post_request(payload, opts) do
+      defp post_request(payload, opts, request_id) do
         {:error, :not_implemented}
       end
 
-      defoverridable post_request: 2
+      defoverridable post_request: 3
 
       defp server_request(params, opts \\ []) do
         timeout = Keyword.get(opts, :request_timeout, Ethereumex.Config.request_timeout())

--- a/lib/ethereumex/config.ex
+++ b/lib/ethereumex/config.ex
@@ -1,8 +1,8 @@
 defmodule Ethereumex.Config do
   @moduledoc false
 
-  @spec rpc_url() :: binary()
-  def rpc_url do
+  @spec web3_url() :: binary()
+  def web3_url do
     case Application.get_env(:ethereumex, :url) do
       url when is_binary(url) and url != "" ->
         url

--- a/lib/ethereumex/http_client.ex
+++ b/lib/ethereumex/http_client.ex
@@ -3,11 +3,11 @@ defmodule Ethereumex.HttpClient do
   import Ethereumex.Config
   @moduledoc false
 
-  @spec post_request(binary(), []) :: {:ok | :error, any()}
-  def post_request(payload, opts) do
+  @spec post_request(binary(), [], integer()) :: {:ok | :error, any()}
+  def post_request(payload, opts, _request_id) do
     headers = [{"Content-Type", "application/json"}]
     options = Ethereumex.Config.http_options()
-    url = Keyword.get(opts, :url) || rpc_url()
+    url = Keyword.get(opts, :url) || web3_url()
 
     with {:ok, response} <- HTTPoison.post(url, payload, headers, options),
          %HTTPoison.Response{body: body, status_code: code} = response do

--- a/lib/ethereumex/ipc_client.ex
+++ b/lib/ethereumex/ipc_client.ex
@@ -3,8 +3,8 @@ defmodule Ethereumex.IpcClient do
 
   @moduledoc false
 
-  @spec post_request(binary(), []) :: {:ok | :error, any()}
-  def post_request(payload, _opts) do
+  @spec post_request(binary(), [], integer()) :: {:ok | :error, any()}
+  def post_request(payload, _opts, _request_id) do
     with {:ok, response} <- Ethereumex.IpcServer.post(payload) do
       with {:ok, decoded_body} <- Poison.decode(response) do
         case decoded_body do

--- a/lib/ethereumex/web_socket_client.ex
+++ b/lib/ethereumex/web_socket_client.ex
@@ -1,0 +1,19 @@
+defmodule Ethereumex.WebSocketClient do
+  alias Ethereumex.WebSocketServer
+  use Ethereumex.Client.BaseClient
+
+  @moduledoc false
+
+  @spec post_request(binary(), [], integer()) :: {:ok | :error, any()}
+  def post_request(payload, _opts, request_id) do
+    response = WebSocketServer.send_message(payload, request_id)
+
+    {:ok, response["result"]}
+  end
+
+  def eth_subscribe(subscription_type) do
+    {:ok, subscription_id} = "eth_subscribe" |> request([subscription_type], [])
+
+    WebSocketServer.subscribe(subscription_id)
+  end
+end

--- a/lib/ethereumex/web_socket_server.ex
+++ b/lib/ethereumex/web_socket_server.ex
@@ -1,0 +1,47 @@
+defmodule Ethereumex.WebSocketServer do
+  require Logger
+  use WebSockex
+  @moduledoc false
+
+  def start_link(url, state \\ %{requests: %{}, subscriptions: %{}}) do
+    WebSockex.start_link(url, __MODULE__, state, name: WebSocketServer)
+  end
+
+  def subscribe(subscription_id) do
+    GenServer.cast(WebSocketServer, {:subscribe, subscription_id, self()})
+  end
+
+  def send_message(message, request_id) do
+    GenServer.cast(WebSocketServer, {:subscribe_once, request_id, self()})
+    WebSockex.send_frame(WebSocketServer, {:text, message})
+
+    receive do
+      decoded_message -> decoded_message
+    end
+  end
+
+  def handle_frame({:text, message}, state) do
+    decoded_message = Poison.decode!(message)
+
+    if decoded_message["method"] == "eth_subscription" do
+      send(
+        state[:subscriptions][decoded_message["params"]["subscription"]],
+        decoded_message["params"]["result"]
+      )
+    else
+      send(state[:requests][decoded_message["id"]], decoded_message)
+    end
+
+    {:ok, state}
+  end
+
+  def handle_info({:"$gen_cast", {:subscribe, subscription_id, pid}}, state) do
+    state = put_in(state, [:subscriptions, subscription_id], pid)
+    {:ok, state}
+  end
+
+  def handle_info({:"$gen_cast", {:subscribe_once, request_id, pid}}, state) do
+    state = put_in(state, [:requests, request_id], pid)
+    {:ok, state}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,11 +33,12 @@ defmodule Ethereumex.Mixfile do
 
   defp deps do
     [
+      {:credo, "~> 0.10.2", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false},
+      {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:httpoison, "~> 1.3.1"},
       {:poison, "~> 4.0.1"},
-      {:credo, "~> 0.10.2", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.19", only: :dev, runtime: false},
-      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false}
+      {:websockex, "0.4.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -24,4 +24,5 @@
   "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
+  "websockex": {:hex, :websockex, "0.4.1", "d7b7191ec3d5dd136683b60114405a5a130a175faade773a07cb52dbd98f9442", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Allows clients to connect to nodes via [WebSocket](https://tools.ietf.org/html/rfc6455)

Other changes:

* Added `request_id` as an argument to `BaseClient.post` and all
inherited modules

  We needed some way to associate responses with requests so we could
send them back to the right `pid`. The `request_id` seemed well fit for
this purpose.